### PR TITLE
Changing the default pseudo random generator

### DIFF
--- a/lib/bagger/workers/neuron.ex
+++ b/lib/bagger/workers/neuron.ex
@@ -44,11 +44,11 @@ defmodule Bagger.Workers.Neuron do
     [item, input_data] = data
     target = List.last(input_data)
     inputs = List.delete_at(input_data, -1)
-
+    :sfmt.seed :os.timestamp
     Agent.update(__MODULE__, fn(map) ->
       Map.put(map, :inputs, inputs)
       |> Map.put(:weights, 1..length(inputs)
-      |> Enum.map(fn(_) -> :rand.uniform() end))
+      |> Enum.map(fn(_) -> :sfmt.uniform() end))
     end)
 
     calculate_output()

--- a/mix.exs
+++ b/mix.exs
@@ -11,14 +11,15 @@ defmodule Bagger.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :exmatrix, :csvlixir],
+    [applications: [:logger, :exmatrix, :csvlixir, :sfmt],
      mod: {Bagger, []}]
   end
 
   defp deps do
     [
       {:csvlixir, "~> 2.0"},
-      {:exmatrix, "~> 0.0.1"}
+      {:exmatrix, "~> 0.0.1"},
+      {:sfmt, git: "https://github.com/jj1bdx/sfmt-erlang.git"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -2,4 +2,5 @@
   "csvlixir": {:hex, :csvlixir, "2.0.3", "297f4217726ef7f0645bd9b3883cdbd6193ac8fe964aeea8eeb4b3406acc46ac", [:mix], []},
   "exmatrix": {:hex, :exmatrix, "0.0.1", "bd91870e87597c890af938e14db6292fc9c0c14870b03b966e7d5e8059c84229", [:mix], [{:benchfella, "~> 0.2.0", [hex: :benchfella, optional: false]}]},
   "exprintf": {:hex, :exprintf, "0.2.0", "6c97364c75ddb848d0d6142ea3d882567369fc60f0b88a009f41470cab068a56", [:mix], []},
-  "matrix": {:hex, :matrix, "0.3.2", "9c826bc3a1117bf5e1c5cdcf3a3d95456c93bc2e127a04e363e9fc90b724f784", [:mix], [{:exprintf, "~> 0.1", [hex: :exprintf, optional: false]}]}}
+  "matrix": {:hex, :matrix, "0.3.2", "9c826bc3a1117bf5e1c5cdcf3a3d95456c93bc2e127a04e363e9fc90b724f784", [:mix], [{:exprintf, "~> 0.1", [hex: :exprintf, optional: false]}]},
+  "sfmt": {:git, "https://github.com/jj1bdx/sfmt-erlang.git", "36e86c3ce52d3692aaead104ad8bbd5ee3f685e6", []}}


### PR DESCRIPTION
According to [this post](http://www.cultivatehq.com/posts/pseudo-random-number-generator-in-elixir/) the default pseudo random generator for elixir/erlang has a quite short period. It is recommended to use [this](https://github.com/jj1bdx/sfmt-erlang) instead. 

When you are working with probabilistic algorithms It is important to use the most optimized PRNG available.